### PR TITLE
Disable key length limits if SHA function will be used

### DIFF
--- a/src/test/scala/com/evolutiongaming/crypto/CryptoSpec.scala
+++ b/src/test/scala/com/evolutiongaming/crypto/CryptoSpec.scala
@@ -15,25 +15,96 @@ class CryptoSpec extends FlatSpec with Matchers {
     original shouldEqual decrypted
   }
 
-  it should "not give same result when encryption and decryption keys are different" in {
+  it should "generate different encrypted strings on every run and should decrypt both" in {
     val secret = "test secret"
     val original = "test data please ignore"
 
     val encrypted = Crypto.encryptAES(original, secret)
-    val decrypted = Crypto.decryptAES(encrypted, "wrongSecret12345")
+    val encrypted2 = Crypto.encryptAES(original, secret)
+    val decrypted = Crypto.decryptAES(encrypted, secret)
+    val decrypted2 = Crypto.decryptAES(encrypted2, secret)
+
+    encrypted should not equal encrypted2
+    original shouldEqual decrypted
+    original shouldEqual decrypted2
+  }
+
+  it should "decrypt data encrypted with same AES key (long)" in {
+    val original = "test data please ignore"
+    val key = "1234567890123456now_it_became_too_long"
+
+    val encrypted = Crypto.encryptAES(original, key)
+    val decrypted = Crypto.decryptAES(encrypted, key)
+
+    original shouldEqual decrypted
+  }
+
+  it should "not give same result when encryption and decryption keys are different" in {
+    val original = "test data please ignore"
+    val key = "1234567890123456"
+    val otherKey = "6543210987654321"
+
+    val encrypted = Crypto.encryptAES(original, key)
+    val decrypted = Crypto.decryptAES(encrypted, otherKey)
 
     original should not equal decrypted
   }
 
-  it should "not encrypt with key bigger than 16 bytes" in {
-    assertThrows[Crypto.AesKeyTooLong](
-      Crypto.encryptAES("", "1234567890123456now_it_became_too_long")
-    )
+  it should "not give same result when encryption and decryption keys are different (long and substring)" in {
+    val original = "test data please ignore"
+    val key = "1234567890123456now_it_became_too_long"
+
+    val encrypted = Crypto.encryptAES(original, key)
+    val decrypted = Crypto.decryptAES(encrypted, key.take(16))
+
+    original should not equal decrypted
+  }
+
+  // backward compatibility tests
+  it should "decrypt with key up to 16 bytes" in {
+    val key = "1234567890123456"
+    val original = "secretvalue"
+
+    val encrypted = "3d458dc2fe2cd11b9e42b2fee8b51f33"
+    Crypto.decryptAES(encrypted, key) shouldEqual original
   }
 
   it should "not decrypt with key bigger than 16 bytes" in {
     assertThrows[Crypto.AesKeyTooLong](
-      Crypto.decryptAES("", "1234567890123456now_it_became_too_long")
+      Crypto.decryptAES("3d458dc2fe2cd11b9e42b2fee8b51f33", "1234567890123456now_it_became_too_long")
     )
   }
+
+  it should "decrypt with key up to 16 bytes (v1)" in {
+    val key = "1234567890123456"
+    val original = "secretvalue"
+
+    val encrypted = "1-BNW/+juEl+2PQunvhx44/g=="
+    Crypto.decryptAES(encrypted, key) shouldEqual original
+  }
+
+  it should "decrypt with key bigger than 16 bytes (v1)" in {
+    val key = "1234567890123456" + "now_it_became_too_long"
+    val original = "secretvalue"
+
+    val encrypted = "1-1oz9Og7x4cOGLLstyGrD/Q=="
+    Crypto.decryptAES(encrypted, key) shouldEqual original
+  }
+
+  it should "decrypt with key up to 16 bytes (v2)" in {
+    val key = "1234567890123456"
+    val original = "secretvalue"
+
+    val encrypted = "2-02LBITbJAb8Mopvgtrd8p3ORc/ipArp6/ozd"
+    Crypto.decryptAES(encrypted, key) shouldEqual original
+  }
+
+  it should "decrypt with key bigger than 16 bytes (v2)" in {
+    val key = "1234567890123456" + "now_it_became_too_long"
+    val original = "secretvalue"
+
+    val encrypted = "2-aNJt/st3SsxhFYQ/ybgpM9vudiHQjUf1JqJD"
+    Crypto.decryptAES(encrypted, key) shouldEqual original
+  }
+  // enb of backward compatibility tests
 }


### PR DESCRIPTION
- Allowing keys longer than 16 symbols if SHA function is used
  - If SHA function is used, then there is no requirement to limit key length (similar as with well known PBE implementations).

- Bugfixes
  - v1 code was written to not use IV, but opted for CTR. This is like impossible combination, the only path without IV is ECB. So, it was changed to ECB with padding "aka" default "AES". There was no sample of old value, so, the choice of ECB with padding default is a guess. 

- New tests
  - For longer keys input.
  - For verifying that IV allows to generate different encoded values with every call.

- Backward compatibility tests
  - For restored v1 decryption and v0 decryption (encrypted values generated with reverse engineering).