### PR TITLE
Return lenient default behaviour for DecryptConfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
   - openjdk11
 
 scala:
-  - 2.13.1
+  - 2.13.2
   - 2.12.11
 
 script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ bintrayOrganization := Some("evolutiongaming")
 
 scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("2.13.1", "2.12.11")
+crossScalaVersions := Seq("2.13.2", "2.12.11")
 
 libraryDependencies ++= Seq(
   "com.typesafe"   % "config"        % "1.4.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.10

--- a/src/main/scala/com/evolutiongaming/crypto/ConfigDecrypter.scala
+++ b/src/main/scala/com/evolutiongaming/crypto/ConfigDecrypter.scala
@@ -1,0 +1,79 @@
+package com.evolutiongaming.crypto
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+import scala.util.Try
+
+/**
+  * Provides decryption of passwords encrypted using [[Crypto.encryptAES]] for Typesafe Config.
+  *
+  * To use extension methods for [[Config]], import from [[ConfigDecrypter.syntax]].
+  *
+  * Configuration parameters:
+  * - `encryptedPasswords` - if not set or `false` password values are treated as plain-text,
+  * if `true` - as cipher-text
+  * - `application.secret` - private key string to use in decryption
+  */
+trait ConfigDecrypter {
+  /**
+    * If set password values are expected to be encrypted, plain-text otherwise
+    */
+  def encryptedPasswordsEnabled: Boolean
+  /**
+    * Decrypts a password value obtaining the plain text
+    */
+  def decryptString(encryptedPassword: String): Try[String]
+  /**
+    * Decrypts a password value obtaining the plain text - throws exceptions if the plain text recovery is not
+    * possible
+    */
+  def decryptStringUnsafe(encryptedPassword: String): String
+  /**
+    * Decrypts a password value at a config path obtaining the plain text
+    */
+  def decryptPath(configPath: String): Try[String]
+  /**
+    * Decrypts a password value at a config path obtaining the plain text - throws exceptions if
+    * the plain text recovery is not possible
+    */
+  def decryptPathUnsafe(configPath: String): String
+}
+
+object ConfigDecrypter {
+  private val EncryptedPasswordsPath = "encryptedPasswords"
+  private val AppSecretPath = "application.secret"
+
+  /**
+    * Provides [[ConfigDecrypter]] functionality as extension methods for [[Config]]
+    */
+  object syntax {
+    @inline implicit def config2ConfigDecrypter(config: Config): ConfigDecrypter = ConfigDecrypter(config)
+  }
+
+  /**
+    * Creates [[ConfigDecrypter]] working on the provided config
+    */
+  def apply(config: Config = ConfigFactory.load()): ConfigDecrypter = new ConfigDecrypter {
+    override def encryptedPasswordsEnabled: Boolean =
+      config.hasPath(EncryptedPasswordsPath) && config.getBoolean(EncryptedPasswordsPath)
+
+    override def decryptStringUnsafe(encryptedPassword: String): String =
+      if (encryptedPasswordsEnabled) {
+        val secret = config.getString(AppSecretPath)
+        Crypto.decryptAES(encryptedPassword, secret)
+      } else {
+        encryptedPassword
+      }
+
+    override def decryptString(encryptedPassword: String): Try[String] = Try {
+      decryptStringUnsafe(encryptedPassword)
+    }
+
+    override def decryptPath(configPath: String): Try[String] = Try {
+      decryptPathUnsafe(configPath)
+    }
+
+    override def decryptPathUnsafe(configPath: String): String =
+      decryptStringUnsafe(config.getString(configPath))
+  }
+}

--- a/src/main/scala/com/evolutiongaming/crypto/DecryptConfig.scala
+++ b/src/main/scala/com/evolutiongaming/crypto/DecryptConfig.scala
@@ -2,20 +2,16 @@ package com.evolutiongaming.crypto
 
 import com.typesafe.config.{Config, ConfigFactory}
 
+/**
+  * @deprecated use ConfigDecrypter which does not swallow decryption failures
+  */
+/*
+TODO: add @deprecated annotation in the next release
+@deprecated("Use ConfigDecrypter which does not swallow decryption failures", since = "3.1.0")
+ */
 object DecryptConfig {
-  private val EncryptedPasswordsPath = "encryptedPasswords"
-  private val AppSecretPath = "application.secret"
-
   def apply(password: String, config: Config = ConfigFactory.load()): String = {
-    if (
-      config.hasPath(EncryptedPasswordsPath) &&
-        config.getBoolean(EncryptedPasswordsPath)
-    ) {
-      val secret = config getString AppSecretPath
-      Crypto.decryptAES(password, secret)
-    } else {
-      password
-    }
+    ConfigDecrypter(config).decryptString(password).getOrElse(password)
   }
 
   implicit class DecryptConfigOps(val self: Config) extends AnyVal {


### PR DESCRIPTION
Introduces ConfigDecrypter as a replacement for DecryptConfig
which doesn't swallow decryption failures.

Closes #25 