### PR TITLE
Provide fallback to plain password for DecryptConfig

### DIFF
--- a/src/main/scala/com/evolutiongaming/crypto/DecryptConfig.scala
+++ b/src/main/scala/com/evolutiongaming/crypto/DecryptConfig.scala
@@ -1,12 +1,15 @@
 package com.evolutiongaming.crypto
 
+import com.evolutiongaming.crypto.Crypto.DecryptAuthException
 import com.typesafe.config.{Config, ConfigFactory}
+
+import scala.util.control.NonFatal
 
 object DecryptConfig {
   private val EncryptedPasswordsPath = "encryptedPasswords"
   private val AppSecretPath = "application.secret"
 
-  def apply(password: String, config: Config = ConfigFactory.load()): String = {
+  def apply(password: String, config: Config = ConfigFactory.load()): String = try {
     if (
       config.hasPath(EncryptedPasswordsPath) &&
         config.getBoolean(EncryptedPasswordsPath)
@@ -16,6 +19,9 @@ object DecryptConfig {
     } else {
       password
     }
+  } catch {
+    case th: DecryptAuthException => throw th
+    case NonFatal(_) => password
   }
 
   implicit class DecryptConfigOps(val self: Config) extends AnyVal {

--- a/src/test/resources/fallback.conf
+++ b/src/test/resources/fallback.conf
@@ -1,0 +1,6 @@
+encryptedPasswords = true
+application {
+  secret = "abcdefghijklmnop"
+}
+
+password = "jboss"

--- a/src/test/scala/com/evolutiongaming/crypto/DecryptConfigSpec.scala
+++ b/src/test/scala/com/evolutiongaming/crypto/DecryptConfigSpec.scala
@@ -53,4 +53,9 @@ class DecryptConfigSpec extends AnyFlatSpec with BeforeAndAfterEach with Matcher
     val password = config.getString("password")
     config.decryptString(password) shouldEqual correctPassword
   }
+
+  it should "fallback to plain password on decryption failure" in {
+    val decrypted = decrypt("fallback.conf")
+    decrypted shouldEqual correctPassword
+  }
 }


### PR DESCRIPTION
With 2.* series we lost so desired fallback mechanism for passwords being treated as un-encrypted on decryption failure.
This PR brings it back with respect of a new `DecryptAuthException`.

Resolves #25 